### PR TITLE
feat: ai knowledge sub modules

### DIFF
--- a/prospec/ai-knowledge/_index.md
+++ b/prospec/ai-knowledge/_index.md
@@ -53,10 +53,11 @@ tests (validates all)
 | Layer | Content | When to Load | Budget |
 |-------|---------|-------------|--------|
 | **L0** | `_index.md` + `_conventions.md` | Every conversation (auto-injected via agent config) | ≤ 1,500 tokens total |
-| **L1** | `modules/{name}/README.md` | When Skill identifies related modules from L0 keywords | ≤ 400 tokens per module |
+| **L1** | `modules/{name}/README.md` (+ any `{sub-module}.md` it links) | When Skill identifies related modules from L0 keywords | ≤ 400 tokens per module |
 | **L2** | Source code files | When Agent needs implementation details | No limit (read on demand) |
 
 **Principles:**
 1. L0 answers "where to look" — L1 answers "how to modify" — L2 answers "how to write"
 2. Each layer must NOT duplicate information available in a lower layer
-3. L1 README is the only file per module — no api-surface.md, dependencies.md, or patterns.md
+3. The README (plus any linked `{sub-module}.md`) is the only knowledge per module — no api-surface.md, dependencies.md, or patterns.md
+4. Sub-modules are an L1 sub-layer reached via the README's `## Sub-Modules` links — never listed in `_index.md`

--- a/prospec/ai-knowledge/_module-readme-conventions.md
+++ b/prospec/ai-knowledge/_module-readme-conventions.md
@@ -43,6 +43,7 @@ The order is fixed. Keep each section concise; the whole README stays **≤ 100 
 | `## Modification Guide` | ✅ | Numbered "to change X, edit Y → Z" recipes for the common edits. This is more valuable than an API dump — tell agents HOW to change. |
 | `## Ripple Effects` | ⬜ | Larger modules only: what downstream breaks when you touch a shared piece. Omit for small leaf modules. |
 | `## Pitfalls` | ✅ | Known traps, surprising names, non-obvious invariants, anti-patterns. |
+| `## Sub-Modules` | ⬜ | Only when this module has extracted sub-module files (see "Sub-Modules" below): a link list to each `{sub-module}.md`. Omit otherwise. |
 
 ## Skeleton
 
@@ -74,8 +75,40 @@ The order is fixed. Keep each section concise; the whole README stays **≤ 100 
 <!-- prospec:user-end -->
 ```
 
+## Sub-Modules (splitting an oversized README)
+
+A module README must stay within budget (≤ 100 lines / ≤ 400 tokens). When a module is large
+enough that trimming would discard genuinely useful detail, AND it contains a
+**content-rich, functionally-independent** area, extract that area into a sub-module file instead
+of trimming it away.
+
+- **When to extract** — both must hold; otherwise just trim:
+  1. The main README would exceed budget even after reasonable trimming.
+  2. There is a self-contained sub-area — rich enough to warrant its own Key Files / Public API /
+     Pitfalls, and independent enough to be understood on its own.
+- **Layout**: `modules/{module}/{sub-module}.md` — a sibling of the module's `README.md`, kebab-case
+  name after the sub-area (e.g. `modules/services/spec-sync.md`). Same Recipe-First structure and
+  same ≤ 100 line / ≤ 400 token budget as a README. If a sub-module would itself overflow, split it
+  again the same way.
+- **Link from the main README**: keep a `## Sub-Modules` section (inside the auto block) listing each:
+  ```markdown
+  ## Sub-Modules
+  - [Spec Sync](./spec-sync.md) — archive → Feature / Product spec synchronisation
+  - [Knowledge Engine](./knowledge-engine.md) — module scan + Recipe-First generation
+  ```
+  The main README keeps the module overview and cross-cutting sections; the extracted detail moves
+  into the sub-module file (do not duplicate it back into the README).
+- **Discovery / loading**: sub-modules are an **L1 sub-layer**, discovered ONLY through the parent
+  README's `## Sub-Modules` links — they are NOT listed in `_index.md` (L0 stays a lean top-level
+  map). Any skill that loads a module's README must also open the linked sub-module file(s) relevant
+  to its task, not stop at the main README.
+- **A sub-module is not a top-level module**: it stays under its parent's directory and is absent
+  from `_index.md` / `module-map.yaml`. If an area is independent enough to deserve its own
+  `_index.md` entry, make it a real module instead of a sub-module.
+
 ## Principles
 
 - **Modification Guide > API Reference** — tell agents HOW to change, not just WHAT exists.
-- **No api-surface.md, dependencies.md, or patterns.md** — everything consolidates into this one README.
+- **No api-surface.md, dependencies.md, or patterns.md** — everything consolidates into the README (or its sub-module files); these are the only knowledge docs per module.
 - **README is a map, not a copy** — point to source files; never duplicate source code or full signatures.
+- **Prefer extraction over lossy trimming** — when a README outgrows its budget and has an independent sub-area, extract a sub-module rather than deleting useful detail.

--- a/src/templates/init/index.md.hbs
+++ b/src/templates/init/index.md.hbs
@@ -26,7 +26,7 @@
 ## How to Use
 
 1. Start by reading this index to understand available modules
-2. Load the specific module's `README.md` for detailed information
+2. Load the specific module's `README.md` for detailed information — and any `{sub-module}.md` it links under `## Sub-Modules`
 3. Check `_conventions.md` for coding patterns and standards
 4. Consult `CONSTITUTION.md` for architectural constraints
 5. Use `module-map.yaml` for dependency relationships

--- a/src/templates/init/module-readme-conventions.md.hbs
+++ b/src/templates/init/module-readme-conventions.md.hbs
@@ -43,6 +43,7 @@ The order is fixed. Keep each section concise; the whole README stays **≤ 100 
 | `## Modification Guide` | ✅ | Numbered "to change X, edit Y → Z" recipes for the common edits. This is more valuable than an API dump — tell agents HOW to change. |
 | `## Ripple Effects` | ⬜ | Larger modules only: what downstream breaks when you touch a shared piece. Omit for small leaf modules. |
 | `## Pitfalls` | ✅ | Known traps, surprising names, non-obvious invariants, anti-patterns. |
+| `## Sub-Modules` | ⬜ | Only when this module has extracted sub-module files (see "Sub-Modules" below): a link list to each `{sub-module}.md`. Omit otherwise. |
 
 ## Skeleton
 
@@ -74,8 +75,40 @@ The order is fixed. Keep each section concise; the whole README stays **≤ 100 
 <!-- prospec:user-end -->
 ```
 
+## Sub-Modules (splitting an oversized README)
+
+A module README must stay within budget (≤ 100 lines / ≤ 400 tokens). When a module is large
+enough that trimming would discard genuinely useful detail, AND it contains a
+**content-rich, functionally-independent** area, extract that area into a sub-module file instead
+of trimming it away.
+
+- **When to extract** — both must hold; otherwise just trim:
+  1. The main README would exceed budget even after reasonable trimming.
+  2. There is a self-contained sub-area — rich enough to warrant its own Key Files / Public API /
+     Pitfalls, and independent enough to be understood on its own.
+- **Layout**: `modules/{module}/{sub-module}.md` — a sibling of the module's `README.md`, kebab-case
+  name after the sub-area (e.g. `modules/services/spec-sync.md`). Same Recipe-First structure and
+  same ≤ 100 line / ≤ 400 token budget as a README. If a sub-module would itself overflow, split it
+  again the same way.
+- **Link from the main README**: keep a `## Sub-Modules` section (inside the auto block) listing each:
+  ```markdown
+  ## Sub-Modules
+  - [Spec Sync](./spec-sync.md) — archive → Feature / Product spec synchronisation
+  - [Knowledge Engine](./knowledge-engine.md) — module scan + Recipe-First generation
+  ```
+  The main README keeps the module overview and cross-cutting sections; the extracted detail moves
+  into the sub-module file (do not duplicate it back into the README).
+- **Discovery / loading**: sub-modules are an **L1 sub-layer**, discovered ONLY through the parent
+  README's `## Sub-Modules` links — they are NOT listed in `_index.md` (L0 stays a lean top-level
+  map). Any skill that loads a module's README must also open the linked sub-module file(s) relevant
+  to its task, not stop at the main README.
+- **A sub-module is not a top-level module**: it stays under its parent's directory and is absent
+  from `_index.md` / `module-map.yaml`. If an area is independent enough to deserve its own
+  `_index.md` entry, make it a real module instead of a sub-module.
+
 ## Principles
 
 - **Modification Guide > API Reference** — tell agents HOW to change, not just WHAT exists.
-- **No api-surface.md, dependencies.md, or patterns.md** — everything consolidates into this one README.
+- **No api-surface.md, dependencies.md, or patterns.md** — everything consolidates into the README (or its sub-module files); these are the only knowledge docs per module.
 - **README is a map, not a copy** — point to source files; never duplicate source code or full signatures.
+- **Prefer extraction over lossy trimming** — when a README outgrows its budget and has an independent sub-area, extract a sub-module rather than deleting useful detail.

--- a/src/templates/knowledge/index.md.hbs
+++ b/src/templates/knowledge/index.md.hbs
@@ -26,10 +26,11 @@ _Table format: Module | Keywords | Status | Description | Rationale | Depends On
 | Layer | Files | When to Load | Token Budget |
 |-------|-------|-------------|-------------|
 | **L0** | `_index.md` + `_conventions.md` | Every conversation (auto-injected via agent config) | ≤ 1,500 tokens total |
-| **L1** | `modules/{name}/README.md` | When Skill identifies related modules from L0 keywords | ≤ 400 tokens per module |
+| **L1** | `modules/{name}/README.md` (+ any `{sub-module}.md` it links) | When Skill identifies related modules from L0 keywords | ≤ 400 tokens per module |
 | **L2** | Source code files | When Agent needs implementation details | No limit (read on demand) |
 
 **Principles:**
 1. L0 answers "where to look" — L1 answers "how to modify" — L2 answers "how to write"
 2. Each layer must NOT duplicate information available in a lower layer
-3. L1 README is the only file per module — no api-surface.md, dependencies.md, or patterns.md
+3. The README (plus any linked `{sub-module}.md`) is the only knowledge per module — no api-surface.md, dependencies.md, or patterns.md
+4. Sub-modules are an L1 sub-layer reached via the README's `## Sub-Modules` links — never listed in `_index.md`

--- a/src/templates/skills/prospec-ff.hbs
+++ b/src/templates/skills/prospec-ff.hbs
@@ -49,7 +49,7 @@ Derive kebab-case change name, confirm before proceeding.
 
 | Step | Action |
 |------|--------|
-| Knowledge | Layer 1 (_index.md) → Layer 2 (related module READMEs) |
+| Knowledge | Layer 1 (_index.md) → Layer 2 (related module READMEs + any `{sub-module}.md` they link) |
 | Scaffold | Create `plan.md` + `delta-spec.md`, update status → `plan` |
 | Populate | Write per plan-format.md and delta-spec-format.md |
 | Check | Constitution check → PASS continue / FAIL pause |

--- a/src/templates/skills/prospec-implement.hbs
+++ b/src/templates/skills/prospec-implement.hbs
@@ -27,7 +27,7 @@ When triggered, briefly describe:
 | Layer | What to Load | When to Load | Budget |
 |-------|-------------|--------------|--------|
 | L0 | `_index.md` + `_conventions.md` + tasks.md + plan.md + delta-spec.md | At startup — navigate modules and understand current tasks | ≤ 1,500 tokens (knowledge) |
-| L1 | Related module `README.md` (Recipe-First) | When starting a task — understand APIs, modification patterns, and ripple effects | ≤ 400 tokens/module |
+| L1 | Related module `README.md` (Recipe-First) **+ any `{sub-module}.md` it links** | When starting a task — understand APIs, modification patterns, and ripple effects | ≤ 400 tokens/module |
 | L2 | Source code files | When implementing — verify details, read exact signatures | On-demand |
 
 **Principles:** L0 is always loaded. L1 is loaded per-module as needed. Never duplicate L2 content in L1.
@@ -89,7 +89,7 @@ After completing each task, verify Knowledge alignment:
 | Check Item | PASS | WARN |
 |------------|------|------|
 | _conventions.md patterns followed | execute()/atomicWrite()/ContentMerger used where applicable | Patterns not followed — justify deviation |
-| Module README consulted | Related module API verified before implementation | Implemented without checking module README |
+| Module README consulted | Related module API verified before implementation, incl. linked sub-modules | Implemented without checking module README / skipped a relevant sub-module |
 | Delta-spec compliance | Implementation matches specification | Deviation documented in tasks.md |
 
 WARN items do not block — document reasoning in task completion notes.

--- a/src/templates/skills/prospec-knowledge-generate.hbs
+++ b/src/templates/skills/prospec-knowledge-generate.hbs
@@ -126,6 +126,12 @@ Changes here affect:
 - [Common mistakes when modifying this module]
 - [Non-obvious constraints or gotchas]
 
+## Sub-Modules
+
+- [Sub Name](./{sub-module}.md) — one-line summary
+
+(Only when this module was split — see "Step 4.5". Omit the section otherwise.)
+
 <!-- prospec:auto-end -->
 
 <!-- prospec:user-start -->
@@ -134,10 +140,19 @@ Changes here affect:
 
 **Key principles:**
 - **Canonical template**: this Recipe-First structure mirrors `{{knowledge_base_path}}/_module-readme-conventions.md` — if the two ever diverge, that file wins. (Section order, `# {ProperName}` title, and the `prospec:auto`/`prospec:user` marker contract are defined there.)
-- **No api-surface.md, dependencies.md, or patterns.md** — all information consolidated into README.md
+- **No api-surface.md, dependencies.md, or patterns.md** — all information consolidated into README.md (or its sub-module files, see Step 4.5)
 - **Modification Guide > API Reference** — tell agents HOW to change, not just WHAT exists
 - **Ripple Effects** — prevent agents from making isolated changes that break other modules
 - **Pitfalls** — capture tribal knowledge that prevents repeated mistakes
+
+### Step 4.5: Extract Sub-Modules (only when a README would overflow)
+
+If a module's README would exceed the ≤100 line / ≤400 token budget even after reasonable trimming, AND it contains a **content-rich, functionally-independent** sub-area, extract that area into a sub-module file instead of trimming away useful detail (canonical rules: `{{knowledge_base_path}}/_module-readme-conventions.md`).
+
+- **Both conditions required** — overflow AND a self-contained sub-area (rich enough for its own Key Files / Public API / Pitfalls, understandable on its own). If only one holds, just trim.
+- **Layout**: `{{knowledge_base_path}}/modules/{module}/{sub-module}.md` — a sibling of `README.md`, kebab-case, same Recipe-First structure and same budget. A sub-module that still overflows is split again the same way.
+- **Link back**: add a `## Sub-Modules` section to the main README listing `[Sub Name](./{sub-module}.md) — one-line`; move the extracted detail into the sub-module file (do not duplicate it back).
+- **Not in `_index.md`**: sub-modules are an L1 sub-layer discovered via the main README only — do NOT add them to `_index.md` or `module-map.yaml` (keep L0 lean). If an area deserves an `_index.md` entry, make it a real top-level module instead.
 
 ### Step 5: Populate _index.md
 
@@ -158,12 +173,12 @@ Also populate the **Loading Rules** section at the bottom:
 | Layer | Content | When to Load | Budget |
 |-------|---------|-------------|--------|
 | L0 | _index.md + _conventions.md | Always (every task) | ≤ {l0_max} tokens |
-| L1 | modules/{name}/README.md | When working on related module | ≤ {l1_per_module} tokens/module |
+| L1 | modules/{name}/README.md (+ linked {sub-module}.md) | When working on related module | ≤ {l1_per_module} tokens/module |
 | L2 | Source code files | When implementation details needed | On-demand |
 
 **Principles:**
 - L0 is loaded on every task — keep it a navigation map, not a reference manual
-- L1 is loaded per-module — only load modules relevant to current task
+- L1 is loaded per-module — only load modules relevant to current task; when a README links sub-modules, also load the relevant ones
 - L2 is never pre-loaded — agent reads source files when needed
 - Never duplicate L2 content in L1 — README points to source, doesn't copy it
 ```
@@ -176,7 +191,8 @@ Naming conventions, project-specific patterns, directory conventions, import ord
 
 - Each module has clear responsibility boundaries
 - No circular dependencies between modules
-- **Each module README ≤ 100 lines** (check and trim if exceeded)
+- **Each module README (and each sub-module) ≤ 100 lines** — if it overflows, first extract a content-rich, independent sub-area (Step 4.5); only trim when there is no such sub-area
+- Every extracted sub-module is linked from its parent README's `## Sub-Modules` section and is NOT listed in `_index.md`
 - README contains all Recipe-First sections (Key Files, Public API, Dependencies, Modification Guide, Ripple Effects, Pitfalls)
 - _index.md has Rationale column and Loading Rules section
 - **L0 total (_index.md + _conventions.md) ≤ 1,500 tokens** (estimate ~4 chars/token)
@@ -192,7 +208,8 @@ Naming conventions, project-specific patterns, directory conventions, import ord
 - **NEVER** ignore Tech Stack info from raw-scan.md — it affects module splitting strategy
 - **NEVER** write outdated file paths in READMEs — all paths must come from raw-scan.md real data
 - **NEVER** generate api-surface.md, dependencies.md, or patterns.md — all info goes in README.md only
-- **NEVER** exceed 100 lines per module README — trim to essential information; agent uses L2 (source) for details
+- **NEVER** exceed 100 lines per module README or sub-module — when it overflows, extract an independent sub-area to `{module}/{sub-module}.md` (Step 4.5) before resorting to lossy trimming; agent uses L2 (source) for details
+- **NEVER** list sub-modules in `_index.md` or `module-map.yaml` — they are an L1 sub-layer reached only via the parent README's `## Sub-Modules` links
 - **NEVER** duplicate source code in README — use function signatures and 1-line descriptions; the README is a map, not a copy
 
 ## Error Handling
@@ -203,5 +220,5 @@ Naming conventions, project-specific patterns, directory conventions, import ord
 | raw-scan.md incomplete | List missing sections, suggest re-running init or manual completion |
 | Module README already exists | Only overwrite auto sections, preserve user sections |
 | Strategy produces <2 modules | Fall back to `architecture` strategy |
-| Module README exceeds 100 lines | Trim Key Files and Public API sections; keep Modification Guide and Pitfalls intact |
+| Module README exceeds 100 lines | If a content-rich, independent sub-area exists → extract a sub-module (Step 4.5) and link it; otherwise trim Key Files and Public API, keeping Modification Guide and Pitfalls intact |
 | Ambiguous project type | Ask user to clarify, or treat as hybrid |

--- a/src/templates/skills/prospec-knowledge-update.hbs
+++ b/src/templates/skills/prospec-knowledge-update.hbs
@@ -28,10 +28,10 @@ Updated knowledge must respect these limits:
 
 | Layer | Content | Budget |
 |-------|---------|--------|
-| L1 | Each module `README.md` | ≤ 400 tokens / ≤ 100 lines per module |
+| L1 | Each module `README.md` (and each `{sub-module}.md`) | ≤ 400 tokens / ≤ 100 lines each |
 | L0 | `_index.md` + `_conventions.md` | ≤ 1,500 tokens total |
 
-After updating, verify the affected README stays within budget. Trim Key Files and Public API if needed — keep Modification Guide and Pitfalls intact.
+After updating, verify the affected README stays within budget. If it overflows and has a content-rich, functionally-independent sub-area, extract a sub-module (see Phase 3a) rather than trimming away useful detail; otherwise trim Key Files and Public API, keeping Modification Guide and Pitfalls intact. Canonical rules: `{{knowledge_base_path}}/_module-readme-conventions.md`.
 
 ## Core Workflow
 
@@ -55,6 +55,7 @@ For each affected module:
 1. Locate module paths from `module-map.yaml` (or infer from module name)
 2. Scan source files (max 20 key files per module)
 3. Infer file descriptions from naming patterns (service.ts, test.ts, etc.)
+4. Read the module's existing `README.md` **and any `{sub-module}.md`** linked from its `## Sub-Modules` section — an update may need to refresh a sub-module, not just the main README
 
 ### Phase 3: Update Knowledge Files
 
@@ -87,6 +88,7 @@ For MODIFIED modules:
 - Update Key Files table, Public API list, dependency info
 - **Refresh Modification Guide** — if implementation patterns changed, update guidance
 - **Refresh Ripple Effects** — if new dependencies were added, update impact list
+- **Maintain sub-modules** — if the module already has `## Sub-Modules` links, update the affected `{sub-module}.md` (and the link's one-liner) instead of cramming the detail back into the README. If the change pushes the README over budget and a content-rich, independent sub-area now exists, extract a new sub-module (`{module}/{sub-module}.md`) and add it to `## Sub-Modules` — do NOT add it to `_index.md`.
 
 #### 3b: Module README.md (REMOVED)
 
@@ -122,8 +124,9 @@ Update the module table within `prospec:auto-start/end` markers using the curren
 - **NEVER** run without either delta-spec.md or manual module specification — one input source is required
 - **NEVER** skip _index.md update — the index must always reflect current module state
 - **NEVER** ignore module-map.yaml when it exists — dependency graph must stay in sync
-- **NEVER** generate api-surface.md, dependencies.md, or patterns.md — all info goes in README.md only
-- **NEVER** exceed 100 lines per module README — trim Key Files and Public API if needed; keep Modification Guide and Pitfalls intact
+- **NEVER** generate api-surface.md, dependencies.md, or patterns.md — all info goes in README.md (or its sub-module files) only
+- **NEVER** exceed 100 lines per module README or sub-module — when it overflows, extract an independent sub-area to `{module}/{sub-module}.md` and link it from `## Sub-Modules` before resorting to lossy trimming
+- **NEVER** list sub-modules in `_index.md` or `module-map.yaml` — they are reached only via the parent README's `## Sub-Modules` links
 
 ## Error Handling
 

--- a/src/templates/skills/prospec-plan.hbs
+++ b/src/templates/skills/prospec-plan.hbs
@@ -29,7 +29,7 @@ When triggered, briefly describe:
 | Layer | What to Load | When to Load | Budget |
 |-------|-------------|--------------|--------|
 | L0 | `_index.md` + `_conventions.md` + Feature Specs + Product Spec | At startup — navigate modules and understand existing requirements | ≤ 1,500 tokens (knowledge) |
-| L1 | Related module `README.md` (Recipe-First) | During architecture design — understand APIs, dependencies, and modification patterns | ≤ 400 tokens/module |
+| L1 | Related module `README.md` (Recipe-First) **+ any `{sub-module}.md` it links** | During architecture design — understand APIs, dependencies, and modification patterns | ≤ 400 tokens/module |
 | L2 | Source code files | When technical questions arise — user can request explicitly | On-demand |
 
 **Principles:** L0 is always loaded. L1 is loaded per-module as needed. Never duplicate L2 content in L1.
@@ -51,7 +51,7 @@ Auto-identify the current change (from directory context or ask user), read and 
 
 **Step 2 — Load Knowledge by Mode:**
 
-- **Brownfield**: Load related module READMEs + `{{knowledge_base_path}}/_conventions.md`. Prepare to synthesize Technical Summary in Phase 4.
+- **Brownfield**: Load related module READMEs (and any `{sub-module}.md` they link) + `{{knowledge_base_path}}/_conventions.md`. Prepare to synthesize Technical Summary in Phase 4.
 - **Greenfield**: Skip module loading. Scan project root for tech stack indicators (`package.json`, `pyproject.toml`, `.prospec.yaml`), top-level directory structure, and 2-3 core source files. Recommend `prospec knowledge init` + `/prospec-knowledge-generate`.
 
 ### Phase 3: Create Scaffolding

--- a/src/templates/skills/prospec-tasks.hbs
+++ b/src/templates/skills/prospec-tasks.hbs
@@ -18,7 +18,7 @@ When triggered, briefly describe:
 2. Read `.prospec/changes/[name]/delta-spec.md` — parse file changes and specifications
 3. Read `.prospec/changes/[name]/design-spec.md` (if exists) — identify UI components for task decomposition
 4. Read `{{constitution_path}}` — prepare test coverage check
-5. Read related module `README.md` from `{{knowledge_base_path}}/modules/` — confirm architecture layers and dependency directions for task ordering
+5. Read related module `README.md` from `{{knowledge_base_path}}/modules/` (and any `{sub-module}.md` it links) — confirm architecture layers and dependency directions for task ordering
 6. **MANDATORY** — Read [`references/tasks-format.md`](references/tasks-format.md) for tasks.md format
 
 ## Core Workflow

--- a/src/templates/skills/prospec-verify.hbs
+++ b/src/templates/skills/prospec-verify.hbs
@@ -28,7 +28,7 @@ When triggered, briefly describe:
 | Layer | What to Load | When to Load | Budget |
 |-------|-------------|--------------|--------|
 | L0 | `_index.md` + `_conventions.md` + all planning docs + Feature Specs | At startup — full context for comprehensive audit | ≤ 1,500 tokens (knowledge) |
-| L1 | All affected module `README.md` (Recipe-First) | During Verification 2/5 and 4/5 — compare spec against knowledge | ≤ 400 tokens/module |
+| L1 | All affected module `README.md` (Recipe-First) **+ any `{sub-module}.md` they link** | During Verification 2/5 and 4/5 — compare spec against knowledge | ≤ 400 tokens/module |
 | L2 | Source code files | During Verification 2/5 — verify implementation matches spec | On-demand |
 
 **Principles:** Verify loads more L1 than other skills (all affected modules, not just current task's module). L2 is loaded to find evidence for PASS/FAIL judgments.

--- a/tests/contract/skill-format.test.ts
+++ b/tests/contract/skill-format.test.ts
@@ -729,6 +729,51 @@ describe('Skill Format Contract', () => {
     });
   });
 
+  describe('AI Knowledge sub-modules', () => {
+    it('module-readme-conventions defines sub-module extraction', () => {
+      const content = renderTemplate(
+        'init/module-readme-conventions.md.hbs',
+        TEMPLATE_CONTEXT,
+      );
+      expect(content).toContain('## Sub-Modules');
+      expect(content).toContain('content-rich, functionally-independent');
+      expect(content).toContain('modules/{module}/{sub-module}.md');
+      expect(content).toContain('NOT listed in');
+    });
+
+    it('knowledge-generate extracts sub-modules instead of lossy trimming', () => {
+      const content = renderTemplate(
+        'skills/prospec-knowledge-generate.hbs',
+        TEMPLATE_CONTEXT,
+      );
+      expect(content).toContain('Step 4.5');
+      expect(content).toContain('## Sub-Modules');
+      expect(content).toContain('content-rich, functionally-independent');
+    });
+
+    it('knowledge-update maintains and extracts sub-modules', () => {
+      const content = renderTemplate(
+        'skills/prospec-knowledge-update.hbs',
+        TEMPLATE_CONTEXT,
+      );
+      expect(content).toContain('## Sub-Modules');
+      expect(content).toContain('sub-module');
+    });
+
+    it('knowledge-consuming skills also load linked sub-modules', () => {
+      for (const name of [
+        'prospec-implement',
+        'prospec-plan',
+        'prospec-verify',
+        'prospec-tasks',
+        'prospec-ff',
+      ]) {
+        const content = renderTemplate(`skills/${name}.hbs`, TEMPLATE_CONTEXT);
+        expect(content).toContain('sub-module');
+      }
+    });
+  });
+
   describe('Agent config skill reference paths', () => {
     it('claude config should point references at .claude/skills', () => {
       const content = renderTemplate('agent-configs/claude.md.hbs', {


### PR DESCRIPTION
## 改動內容

本分支為 AI Knowledge 三層載入體系（L0/L1/L2）新增 **「Sub-Modules（子模組）」L1 子層**，解決單一 module `README.md` 在超出 ≤ 100 行 / ≤ 400 token 預算時，過去只能「有損裁剪（lossy trimming）」而丟失有用細節的問題；改以「將內容豐富、功能獨立的子區塊抽取成 `{sub-module}.md`」取代裁剪，並讓所有**產生、更新、消費** knowledge 的 skill 模板與本 repo 自身 dogfood 文件同步認識此概念。本分支僅建立規範與流程，**未實際抽取任何子模組檔案**（全部為 `M`，無 `A`）。

- **定義子模組抽取規範（canonical convention）**：
  - 在 `module-readme-conventions` 的 README section 表新增 `## Sub-Modules` 列（⬜ 選填，僅當已抽取子模組時出現）。
  - 新增完整「Sub-Modules (splitting an oversized README)」說明區：何時抽取（兩條件須同時成立，否則只裁剪）、檔案 layout、回連 README、discovery/loading 規則、子模組 ≠ 頂層模組。
  - Principles 段補強：將「No api-surface.md…」延伸為「(or its sub-module files)」，並新增「Prefer extraction over lossy trimming」原則。
- **產生端流程（`prospec-knowledge-generate`）新增 Step 4.5**：
  - README 範本內加入 `## Sub-Modules` section 範例與「僅當分割時保留」註記。
  - 新增 Step 4.5「Extract Sub-Modules」：兩條件、layout、回連、禁止寫入 `_index.md`。
  - Loading Rules 表、Quality Gate、NEVER 清單、Error Handling 表全數同步（README 超 100 行 → 先抽子模組再裁剪）。
- **更新端流程（`prospec-knowledge-update`）新增子模組維護**：
  - Budget 表 L1 涵蓋 each `{sub-module}.md`。
  - Phase 2 新增第 4 步：掃描時須一併讀取 README 連結的 `{sub-module}.md`。
  - Phase 3（MODIFIED 模組）新增「Maintain sub-modules」步驟與對應 NEVER 規則。
- **消費端 skill 一律連同子模組載入**：
  - `prospec-implement` / `prospec-plan` / `prospec-verify` / `prospec-ff` / `prospec-tasks` 五個 skill 的 Loading Rules 與 Knowledge 載入步驟，全部補上「+ any `{sub-module}.md` it links」。
  - `init/index.md.hbs`、`knowledge/index.md.hbs` 的 How to Use / Loading Rules 同步。
- **Dogfood 至本 repo 自身 knowledge**：
  - `prospec/ai-knowledge/_index.md` 與 `_module-readme-conventions.md` 套用同一份規範（與對應模板 blob 一致），維持「自身就是範例」的一致性。
- **契約測試守門**：
  - `skill-format.test.ts` 新增 `AI Knowledge sub-modules` describe，以 4 個 case 驗證規範、產生端、更新端與五個消費端 skill 均含子模組語意。

---

## Skill 模板規範變更

本分支核心落在 `src/templates/`（commit `e06bb90`，11 檔）。模板是 `prospec` CLI 對外產出的資源，因此這裡的每一處改動都會傳遞到使用者專案產生的 skill 與 knowledge 文件。

### 規範定義 — `src/templates/init/module-readme-conventions.md.hbs`（+35）

此檔為 module README 的 **canonical template**，產生／更新端皆對齊它。本分支新增：

| 變更點 | 內容 |
|---|---|
| Section 表新列 | 新增 `\| ## Sub-Modules \| ⬜ \|` ——僅當模組已抽取子模組時，列出指向各 `{sub-module}.md` 的連結清單；否則整段省略 |
| 新增說明區 | 「Sub-Modules (splitting an oversized README)」完整定義抽取策略（見下） |
| Principles 補充 | 「No api-surface.md…」延伸為「(or its sub-module files)」；新增「Prefer extraction over lossy trimming」 |

「Sub-Modules」說明區的關鍵規則：

- **When to extract（兩條件須同時成立，否則只裁剪）**：① README 即使合理裁剪後仍超預算；② 存在自足子區塊——內容豐富到值得自己的 Key Files / Public API / Pitfalls，且能獨立理解。
- **Layout**：`modules/{module}/{sub-module}.md`，與 README 同層、kebab-case 命名、套用相同 Recipe-First 結構與 ≤ 100 行 / ≤ 400 token 預算；子模組若再溢出，以同法再切。
- **Link from README**：README 內保留 `## Sub-Modules` section（位於 auto 區塊內）逐項連結；抽取的細節移入子模組檔，**不得回填**至 README。
- **Discovery / loading**：子模組是 **L1 子層**，僅能透過父 README 的 `## Sub-Modules` 連結被發現，**不列入 `_index.md`**（L0 維持精簡的頂層地圖）；任何載入該 README 的 skill 須一併開啟與任務相關的子模組檔。
- **子模組 ≠ 頂層模組**：須留在父模組目錄下，且不出現於 `_index.md` / `module-map.yaml`；若某區塊獨立到值得 `_index.md` 條目，應改建為真正的頂層 module。

### 產生端 — `src/templates/skills/prospec-knowledge-generate.hbs`（+29 / 本檔最大改動）

| 區段 | 變更 |
|---|---|
| README 範本 | 在 `prospec:auto-end` 前插入 `## Sub-Modules` section 範例與「僅當分割時保留，見 Step 4.5」註記 |
| Key principles | 「No api-surface.md…」補上「(or its sub-module files, see Step 4.5)」 |
| **新增 Step 4.5** | 「Extract Sub-Modules (only when a README would overflow)」：重申兩條件、layout、回連、禁入 `_index.md` |
| Loading Rules 表 | L1 列補「(+ linked `{sub-module}.md`)」；原則補「when a README links sub-modules, also load the relevant ones」 |
| Quality Gate | ≤ 100 行檢查改為「先抽 content-rich 獨立子區塊（Step 4.5），無此區塊才裁剪」；新增「每個抽取子模組須由父 README 連結且不列 `_index.md`」 |
| NEVER 清單 | 超 100 行 → 改為先抽子模組再裁剪；新增「NEVER list sub-modules in `_index.md` or `module-map.yaml`」 |
| Error Handling | 「README exceeds 100 lines」改為「有獨立子區塊 → 抽子模組並連結；否則裁剪 Key Files / Public API，保留 Modification Guide 與 Pitfalls」 |

### 更新端 — `src/templates/skills/prospec-knowledge-update.hbs`（+11）

| 區段 | 變更 |
|---|---|
| Budget 表 | L1 由「Each module README.md」擴為「(and each `{sub-module}.md`) ≤ 400 tokens / ≤ 100 lines each」；超預算時導向抽取而非裁剪 |
| Phase 2 | 新增第 4 步：掃描時讀取 README **及其 `## Sub-Modules` 連結的 `{sub-module}.md`**——更新可能需刷新子模組而非主 README |
| Phase 3（MODIFIED 模組） | 新增「Maintain sub-modules」：既有子模組改更新對應 `{sub-module}.md`（含一行摘要）而非回填 README；若改動使 README 超預算且出現獨立子區塊，抽新子模組並加入 `## Sub-Modules`，**不入 `_index.md`** |
| NEVER 清單 | 同步新增「不超 100 行則先抽子模組」「不在 `_index.md` / `module-map.yaml` 列子模組」 |

### 消費端 — 5 個 skill + 2 個 index 模板

下列模板僅在「載入 L1 knowledge」處補上同一句語意——**README 連結的相關子模組也要一併載入**：

| 檔案（±行） | 變更位置 |
|---|---|
| `prospec-implement.hbs`（+4） | Loading Rules L1 列補「+ any `{sub-module}.md` it links」；Knowledge alignment 表「Module README consulted」擴為「incl. linked sub-modules」 |
| `prospec-plan.hbs`（+4） | Loading Rules L1 列補；Step 2 Brownfield 載入補「(and any `{sub-module}.md` they link)」 |
| `prospec-verify.hbs`（+2） | Loading Rules L1 列補「+ any `{sub-module}.md` they link」 |
| `prospec-ff.hbs`（+2） | Knowledge 步驟由「related module READMEs」擴為「+ any `{sub-module}.md` they link」 |
| `prospec-tasks.hbs`（+2） | Phase 1 第 5 步讀 README 補「(and any `{sub-module}.md` it links)」 |
| `init/index.md.hbs`（+2） | How to Use 第 2 步補「and any `{sub-module}.md` it links under `## Sub-Modules`」 |
| `knowledge/index.md.hbs`（+5） | Loading Rules L1 列補；Principles 改寫第 3 點並新增第 4 點（子模組為 L1 子層，永不列 `_index.md`） |

---

## AI Knowledge（dogfood 同步）

commit `0168ebf` 將上述規範套回本 repo 自身的 knowledge base（2 檔），維持「文件本身即遵循其所定義規範」的一致性。兩檔分別是對應模板的鏡像（blob 與模板一致）。

`prospec/ai-knowledge/_module-readme-conventions.md` 變更：
- Section 表新增 `## Sub-Modules` ⬜ 列。
- 新增完整「Sub-Modules (splitting an oversized README)」說明區（內容同 `init/module-readme-conventions.md.hbs`）。
- Principles 補「(or its sub-module files)」與「Prefer extraction over lossy trimming」。

`prospec/ai-knowledge/_index.md` 變更：
- Loading Rules 表 L1 列補「(+ any `{sub-module}.md` it links)」。
- Principles 第 3 點改寫為「README（含連結子模組）為每模組唯一 knowledge」；新增第 4 點「Sub-modules 為 L1 子層，經 README 的 `## Sub-Modules` 連結觸及，永不列入 `_index.md`」。

---

## 測試涵蓋

`tests/contract/skill-format.test.ts`（+45）新增一組 `describe('AI Knowledge sub-modules')`，以 render 後的字串斷言守住規範擴散，無遺漏任一環節：

| 測試 case | 驗證對象 | 關鍵斷言 |
|---|---|---|
| `module-readme-conventions defines sub-module extraction` | `init/module-readme-conventions.md.hbs` | 含 `## Sub-Modules`、`content-rich, functionally-independent`、`modules/{module}/{sub-module}.md`、`NOT listed in` |
| `knowledge-generate extracts sub-modules instead of lossy trimming` | `prospec-knowledge-generate.hbs` | 含 `Step 4.5`、`## Sub-Modules`、`content-rich, functionally-independent` |
| `knowledge-update maintains and extracts sub-modules` | `prospec-knowledge-update.hbs` | 含 `## Sub-Modules`、`sub-module` |
| `knowledge-consuming skills also load linked sub-modules` | `prospec-implement` / `prospec-plan` / `prospec-verify` / `prospec-tasks` / `prospec-ff` | 五個 skill render 後皆含 `sub-module` |

採 render-then-assert 模式，與既有契約測試一致；以「字串存在性」確保規範未在任一模板被遺漏，但不驗證語意正確性（見設計重點）。

---

## 設計重點總結

1. **分層不可見性（L1 子層）**：子模組刻意被排除於 L0（`_index.md` / `module-map.yaml`），只能經父 README 的 `## Sub-Modules` 連結觸及——以「保持 L0 為精簡頂層地圖」為橫切原則，避免索引膨脹反噬 ≤ 1,500 token 的 L0 預算。
2. **抽取優先於裁剪（防資訊流失）**：核心決策是「兩條件同時成立才抽取，否則裁剪」。此規則同時寫入規範、產生端 Step 4.5、更新端 Phase 3 與雙方 NEVER 清單，形成**單一事實來源（conventions 檔）+ 多處引用**的一致約束。
3. **單一來源、模板鏡像 dogfood**：`init/module-readme-conventions.md.hbs` 與 `prospec/ai-knowledge/_module-readme-conventions.md` 維持相同 blob——規範定義與自身實踐綁定，降低兩處漂移（drift）風險；模板內也明示「若 skill 內嵌模板與此檔分歧，以此檔為準」。
4. **產生 / 更新 / 消費三端對齊**：同一概念被拆解為三種職責——產生端（Step 4.5 抽取）、更新端（維護既有子模組或新抽）、消費端（載入時連同子模組）——每端僅補與其職責相符的最小語句，改動面雖廣但每處皆 surgical。
5. **契約測試僅守存在性、不守語意**：新測試以字串斷言確保規範擴散到所有相關模板，能防「漏改某個 skill」，但無法驗證抽取邏輯是否真正被遵循——實際抽取行為仍依賴 skill 執行期判斷，此為本分支驗證範圍的已知邊界。