### PR TITLE
docs(constitution): require bulleted commit bodies; align git conventions

### DIFF
--- a/prospec/CONSTITUTION.md
+++ b/prospec/CONSTITUTION.md
@@ -24,6 +24,7 @@
 **Enforcement**:
 - Each commit message follows Conventional Commits format (`feat:`, `fix:`, `refactor:`, `test:`, `docs:`, `chore:`)
 - Commit messages (subject and body) must be written in English
+- The commit body (the detail below the subject) must be presented as a bulleted list — prose paragraphs are prohibited
 - A single commit must not contain unrelated functional changes
 - Commit messages must not include AI co-authorship attribution
 
@@ -90,9 +91,9 @@
 
 - **Testing**: All public functions must have unit tests; coverage ≥ 80%
 - **Documentation**: Change documents in Traditional Chinese; code in English; root `README.md` kept current with user-facing changes ([SHOULD] — verify WARNs on a gap)
-- **Commits**: Follow Conventional Commits; atomic commits by feature; messages in English
+- **Commits**: Follow Conventional Commits; atomic commits by feature; messages in English; commit bodies as bulleted lists (no prose paragraphs)
 - **Requirements**: User Stories must satisfy INVEST with explicit acceptance criteria
 
 ---
 
-> Last updated: 2026-06-12
+> Last updated: 2026-06-14

--- a/prospec/ai-knowledge/_conventions.md
+++ b/prospec/ai-knowledge/_conventions.md
@@ -118,8 +118,7 @@ Use `mergeContent()` from `lib/content-merger.ts` when updating files that may h
 ## Git Conventions
 
 - Conventional commits: `feat:`, `fix:`, `refactor:`, `docs:`, `test:`, `chore:`, `perf:`, `ci:`
-- No AI attribution in commit messages
-- Feature branches with squash merge
+- No AI co-authorship attribution in commit messages
 <!-- prospec:auto-end -->
 
 <!-- prospec:user-start -->


### PR DESCRIPTION
## What
- **Principle 2 (Atomic Commits by Feature)** — add an Enforcement rule: the commit **body** must be presented as a **bulleted list**; prose paragraphs are prohibited.
- Mirror the rule in the **Commits** quality standard; bump `Last updated` to 2026-06-14.
- Tidy `_conventions.md` Git Conventions: align the AI-attribution wording to "No AI co-authorship attribution" and drop the stale "Feature branches with squash merge" bullet.

## Why
- Codifies an existing team preference into an enforceable Constitution rule.

## Scope
- Docs only — `prospec/CONSTITUTION.md`, `prospec/ai-knowledge/_conventions.md`. No code/tests.

> Note: the `_conventions.md` edit sits inside the `prospec:auto-start/end` section, so a future `knowledge generate/update` could regenerate it.