### PR TITLE
fix: scope import-direction to JS/TS with honest skip for other languages

### DIFF
--- a/src/lib/drift-sources.ts
+++ b/src/lib/drift-sources.ts
@@ -281,7 +281,15 @@ export function collectMarkdownLinks(roots: string[], cwd: string): LinkSource {
   return { available: true, links };
 }
 
-/** Collect cross-module static import edges, attributed via module-map paths. */
+/**
+ * Collect cross-module static import edges, attributed via module-map paths.
+ * Deliberately JS/TS-only: it parses ES-module `import … from` / side-effect
+ * imports. Other languages resolve imports through their own systems (package
+ * roots, namespaces) a lightweight scan cannot follow, and each has a
+ * purpose-built architecture linter (import-linter, deptrac, packwerk,
+ * dependency-cruiser, go-arch-lint, …) that does it properly — so on a project
+ * with no JS/TS source this reports honest `skipped`, never a vacuous PASS.
+ */
 export function collectImportEdges(cwd: string, moduleMap: ModuleMap): ImportEdgeSource {
   const toModule = moduleAttributor(moduleMap);
   // Whole-content matching so multi-line `import { … }\nfrom 'x'` statements are
@@ -290,21 +298,21 @@ export function collectImportEdges(cwd: string, moduleMap: ModuleMap): ImportEdg
   const importPattern =
     /(?:^|\n)\s*(?:(?:import|export)\s+[^;'"`]*?from\s*|import\s*)['"]([^'"]+)['"]/g;
   const edges: ImportEdge[] = [];
-  let anyPathExists = false;
+  let anyJsTsSource = false;
   for (const entry of moduleMap.modules) {
     for (const prefix of entry.paths) {
       const isGlob = prefix.includes('*');
-      // A literal dir prefix is gated by its on-disk existence. A domain glob
-      // ('**/auth/**') has no literal path to stat — `existsSync` on it is
-      // always false — so it is scanned directly and counts as available only
-      // when the glob actually matches files (domain projects relied on the
-      // import-direction check silently degrading to `skipped` before this).
+      // A literal dir prefix is gated by its on-disk existence; a domain glob
+      // ('**/auth/**') has no literal path to stat, so it is scanned directly.
       if (!isGlob && !existsSync(path.resolve(cwd, prefix))) continue;
       const pattern = importScanPattern(prefix, cwd);
       if (pattern === null) continue; // non-source file entry — carries no import edges
       const { files } = scanDirSync(pattern, { cwd });
-      if (isGlob && files.length === 0) continue;
-      anyPathExists = true;
+      // The check is `available` only where JS/TS source is actually found —
+      // a path (or whole project) with no .ts/.js contributes nothing, so a
+      // non-JS/TS project degrades to honest `skipped`, not a vacuous PASS.
+      if (files.length === 0) continue;
+      anyJsTsSource = true;
       for (const relPath of files) {
         const fromModule = toModule(relPath);
         if (fromModule !== entry.name) continue; // longest-prefix owner emits the edge once
@@ -331,10 +339,11 @@ export function collectImportEdges(cwd: string, moduleMap: ModuleMap): ImportEdg
       }
     }
   }
-  if (!anyPathExists) {
+  if (!anyJsTsSource) {
     return {
       available: false,
-      reason: 'source unavailable: none of the module paths exist on disk',
+      reason:
+        "source unavailable: no JavaScript/TypeScript source under module paths (import-direction is JS/TS-only — use your language's import linter, e.g. import-linter / deptrac / packwerk, for others)",
       edges: [],
     };
   }

--- a/tests/unit/lib/drift-sources.test.ts
+++ b/tests/unit/lib/drift-sources.test.ts
@@ -273,6 +273,18 @@ describe('collectImportEdges', () => {
     expect(r.reason).toContain('source unavailable');
   });
 
+  it('reports skipped (not a vacuous PASS) for a non-JS/TS project whose module paths exist but hold no JS/TS source', () => {
+    // The dirs exist and contain source — but Python, not JS/TS. import-direction
+    // is JS/TS-only, so it must degrade to skipped, never report available/PASS
+    // (which would falsely claim the dependency direction was verified).
+    write('src/services/main.py', 'from ..cli.app import x\n');
+    write('src/cli/app.py', 'pass\n');
+    const r = collectImportEdges(tmpDir, MODULE_MAP);
+    expect(r.available).toBe(false);
+    expect(r.reason).toContain('JavaScript/TypeScript');
+    expect(r.edges).toEqual([]);
+  });
+
   it('ignores imports inside block comments (commented-out code is not an edge)', () => {
     write(
       'src/types/x.ts',


### PR DESCRIPTION
## 摘要

drift 的 **import-direction** 檢查只解析 JS/TS ES-module import,但在**非 JS/TS 專案**上,它掃到 0 個 JS/TS 檔卻仍回報 `available` + 0 邊 →評估為 **PASS**——一個空洞 PASS,假裝依賴方向已驗、實際一個檔都沒看,違反 drift 引擎「來源不可得 → skipped,絕不空洞 PASS」的原則。

本 PR 把 import-direction **明確收斂為 JS/TS-only + 誠實 skipped**:

- `available` 僅在**實際掃到 JS/TS 源碼檔**時成立;module paths 下無任何 JS/TS 源碼(即使目錄存在、含其他語言)→ 回報 `skipped`,原因明示「JS/TS-only」並**指向該語言的原生 import linter**(import-linter / deptrac / packwerk / dependency-cruiser …)。
- JS/TS 專案行為完全不變(edge 蒐集、歸屬、排序);既有測試續綠。

## 為什麼不做跨語言解析

一度嘗試以 tree-sitter 擴充為 11 語言(見已擱置的 spike),但在一個大型真實 Python 專案上驗證發現:主流的絕對 import(`from <pkg>.x`,佔 ~84%)需要 package-root 解析,等於重寫各語言成熟的架構 linter,ROI 低且維護重(+22MB grammar、WASM 依賴)。**每個語言都有專門、AST 精準的原生工具**(Python import-linter、PHP deptrac、Ruby packwerk、JS/TS dependency-cruiser、Java ArchUnit …),prospec 不該重造。誠實 skipped + 指路,遠優於誤導的空洞 PASS。

## 驗證

- 全套件綠、typecheck 乾淨、mutation-verified(還原 guard → 非-JS/TS 測試轉紅)。
- **大型真實 Python 專案實測**:import-direction 由「partial/vacuous PASS」改為 `skipped`(帶 JS/TS-only + import-linter 指路)。
