### PR TITLE
fix(knowledge): reclassify _status-lifecycle.md as demand-knowledge

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg?style=flat-square)](LICENSE)
 [![TypeScript](https://img.shields.io/badge/TypeScript-5.9-blue?style=flat-square&logo=typescript)](https://www.typescriptlang.org/)
-[![Tests](https://img.shields.io/badge/tests-4670%20total-success?style=flat-square)](tests/)
+[![Tests](https://img.shields.io/badge/tests-4671%20total-success?style=flat-square)](tests/)
 [![Node](https://img.shields.io/badge/node-%3E%3D22.13-brightgreen?style=flat-square&logo=node.js)](https://nodejs.org/)
 [![pnpm](https://img.shields.io/badge/pnpm-%3E%3D11-orange?style=flat-square&logo=pnpm)](https://pnpm.io/)
 
@@ -1155,7 +1155,7 @@ src/
 ## Testing
 
 ```bash
-# Run all tests (4670 total; 4 skipped)
+# Run all tests (4671 total; 4 skipped)
 pnpm test
 
 # Watch mode
@@ -1168,8 +1168,8 @@ pnpm run typecheck
 pnpm run lint
 ```
 
-**Test Coverage**: 4670 total tests (4666 passed; 4 skipped) across 4 categories:
-- Unit tests (types + lib + services + cli): 3319 tests
+**Test Coverage**: 4671 total tests (4667 passed; 4 skipped) across 4 categories:
+- Unit tests (types + lib + services + cli): 3320 tests
 - Contract tests (CLI output + Skill format): 1175 tests
 - Integration tests: 45 tests
 - E2E tests: 131 tests

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -4,7 +4,7 @@
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg?style=flat-square)](LICENSE)
 [![TypeScript](https://img.shields.io/badge/TypeScript-5.9-blue?style=flat-square&logo=typescript)](https://www.typescriptlang.org/)
-[![測試](https://img.shields.io/badge/測試-4670%20總計-success?style=flat-square)](tests/)
+[![測試](https://img.shields.io/badge/測試-4671%20總計-success?style=flat-square)](tests/)
 [![Node](https://img.shields.io/badge/node-%3E%3D22.13-brightgreen?style=flat-square&logo=node.js)](https://nodejs.org/)
 [![pnpm](https://img.shields.io/badge/pnpm-%3E%3D11-orange?style=flat-square&logo=pnpm)](https://pnpm.io/)
 
@@ -1135,7 +1135,7 @@ src/
 ## 測試
 
 ```bash
-# 執行所有測試（共 4670 個；4 個略過）
+# 執行所有測試（共 4671 個；4 個略過）
 pnpm test
 
 # Watch 模式
@@ -1148,8 +1148,8 @@ pnpm run typecheck
 pnpm run lint
 ```
 
-**測試覆蓋率**：共 4670 個測試（4666 個通過；4 個略過），橫跨 4 大類：
-- Unit tests（types + lib + services + cli）：3319 tests
+**測試覆蓋率**：共 4671 個測試（4667 個通過；4 個略過），橫跨 4 大類：
+- Unit tests（types + lib + services + cli）：3320 tests
 - Contract tests（CLI 輸出 + Skill 格式）：1175 tests
 - Integration tests：45 tests
 - E2E tests：131 tests

--- a/docs/i18n.js
+++ b/docs/i18n.js
@@ -46,7 +46,7 @@
     'hero.lbl2': '// 啟動任何專案 —— 新專案或既有專案皆可',
     'hero.ctaPrimary': '約 5 分鐘快速上手 <span class="arr" aria-hidden="true">→</span>',
     'hero.ctaGhost': '在 GitHub 上查看',
-    'hero.facts.tests': '共 <b>4,670</b> 個測試 · <b>4,666</b> 個通過 · <b>4</b> 個略過',
+    'hero.facts.tests': '共 <b>4,671</b> 個測試 · <b>4,667</b> 個通過 · <b>4</b> 個略過',
     'hero.facts.skills': '<b>17</b> 個 Skills',
     'hero.facts.principles': '<b>8</b> 條強制原則',
     'hero.facts.mcp': '唯讀 <b>MCP</b> server',

--- a/docs/index.html
+++ b/docs/index.html
@@ -159,7 +159,7 @@
     </div>
 
     <div class="hero__facts">
-      <span data-i18n="hero.facts.tests"><b>4,670</b> total · <b>4,666</b> passed · <b>4</b> skipped</span><span class="sep" aria-hidden="true">·</span>
+      <span data-i18n="hero.facts.tests"><b>4,671</b> total · <b>4,667</b> passed · <b>4</b> skipped</span><span class="sep" aria-hidden="true">·</span>
       <span data-i18n="hero.facts.skills"><b>17</b> skills</span><span class="sep" aria-hidden="true">·</span>
       <span data-i18n="hero.facts.principles"><b>8</b> enforced principles</span><span class="sep" aria-hidden="true">·</span>
       <span data-i18n="hero.facts.mcp">read-only <b>MCP</b> server</span><span class="sep" aria-hidden="true">·</span>

--- a/prospec/ai-knowledge/module-map.yaml
+++ b/prospec/ai-knowledge/module-map.yaml
@@ -55,7 +55,7 @@ modules:
       - MCP 契約
       - 模組分類
     rationale: Leaf module with zero internal deps — all others import from here
-    last_verified: 2026-09-02T04:07:58.774Z
+    last_verified: 2026-09-02T07:46:24.900Z
   - name: lib
     description: Shared stateless utilities — config, file I/O, Handlebars
       rendering, scanning, token accounting, the zero-LLM drift engine
@@ -268,7 +268,7 @@ modules:
     rationale: Pure resources — no logic, consumed by lib/template.ts
     last_verified: 2026-09-02T04:07:58.774Z
   - name: tests
-    description: 4-layer test suite — 189 files, 4,670 tests (unit 3319 + contract
+    description: 4-layer test suite — 189 files, 4,671 tests (unit 3320 + contract
       1175 + integration 45 + e2e 131). Validates every module — format and
       public-document contracts, the cli-first probe + station-command
       contracts, the drift engine, token corpus, and the MCP protocol over
@@ -309,4 +309,4 @@ modules:
       - 驗證
       - vitest
     rationale: Quality gate — validates all layers with pyramid coverage
-    last_verified: 2026-09-02T04:07:58.774Z
+    last_verified: 2026-09-02T07:46:24.900Z

--- a/prospec/ai-knowledge/modules/tests/README.md
+++ b/prospec/ai-knowledge/modules/tests/README.md
@@ -1,6 +1,6 @@
 # Verification Suite
 
-> 4-layer Vitest suite (fast-glob/git bypass memfs — 189 test files, 4,670 tests (unit 3319, contract 1175, integration 45, e2e 131)).
+> 4-layer Vitest suite (fast-glob/git bypass memfs — 189 test files, 4,671 tests (unit 3320, contract 1175, integration 45, e2e 131)).
 <!-- prospec:module-readme-format 2026-09-01 -->
 
 <!-- prospec:auto-start -->

--- a/prospec/ai-knowledge/raw-scan.md
+++ b/prospec/ai-knowledge/raw-scan.md
@@ -219,12 +219,12 @@ tests/
 > alphabetically first.
 
 - `tests/fixtures/` — 614 files: `.md`, `.yaml`, `.json`, `.txt`
-- `prospec/` — 262 files: `.md`, `.yaml`
+- `prospec/` — 263 files: `.md`, `.yaml`
 - `planning/` — 10 files: `.md`
 
 ## File Stats
 
 | Metric | Value |
 |--------|-------|
-| Total files | 1360 |
+| Total files | 1362 |
 | Scan depth | 10 |

--- a/prospec/index.md
+++ b/prospec/index.md
@@ -11,13 +11,13 @@ These files are NOT auto-loaded. The AI MUST actively read them at the start of 
 - `prospec/ai-knowledge/_conventions.md`
 - `prospec/ai-knowledge/_diagram-conventions.md`
 - `prospec/ai-knowledge/_glossary.md`
-- `prospec/ai-knowledge/_status-lifecycle.md`
 
 **Load-on-Demand Conventions**
 Load these specific convention files only when their topics are relevant to the task:
 - `prospec/ai-knowledge/_lessons-ledger.md`
 - `prospec/ai-knowledge/_module-readme-conventions.md`
 - `prospec/ai-knowledge/_playbook.md`
+- `prospec/ai-knowledge/_status-lifecycle.md`
 
 ## Modules
 
@@ -28,7 +28,7 @@ Load these specific convention files only when their topics are relevant to the 
 | **services** | init, knowledge, change, archive, agent-sync, invocation-guidance, spec-sync, product, feature-map, triggers, language, measure, check, mcp, serve, status, change-log, change-status, change-scale, change-progress, review-merge, verify-record, learn, validate, spec-show, upgrade, cascade, auto-draft | 服務, 業務邏輯, business logic, execute pattern, use case, 量測報告, 漂移檢查, 真相層 | Active | Business logic — one `execute()` service per command — including shared-output agent invocation-guidance rendering — init / quickstart / upgrade, knowledge init + update, change story / plan / tasks / log / status / scale / progress, review merge, verify record, learn, validate, archive + spec-sync + finalize, agent-sync, measure, drift check (record-review / record-tests / escaped-defect / auto-draft modes), auto-draft, and the read-only MCP server. | Isolates business logic from I/O layer, enables testability | types, lib |
 | **cli** | commands, formatters, commander, output, preaction, measure, check, strict, mcp, stdio, archive, dry-run, station-commands, skill-invocation, finalize, sanitize, auto-draft | 指令, 命令列, command line, 終端, entry point | Active | Thin CLI entry — 18 top-level Commander commands + 29 formatters that parse → call one service → format output; the cli-first station commands each add one command/formatter pair, never logic. | Thin I/O layer: no business logic, delegates to services | types, lib, services |
 | **templates** | handlebars, auto-draft, hbs, skills, agent-configs, invocation-matrix, recipe-first, loading-rules, references, change, stable-prefix, entry-gate, scale, kind, ci-workflow, flywheel, lessons-ledger, feature-map, category, grouping, cli-probe, cli-first | 模板, 範本, handlebars, template engine, resources, 穩定前綴, 知識同步閘門, 複雜度適配, CI 閘門 | Active | Handlebars template library — 17 skills + host-labelled invocation entry guidance, 8 shared partials, 30 references, 1 agent-config, 5 change, 15 init/knowledge (77 `.hbs` templates) — the source of every generated skill, README, and index; every skill delegates its deterministic steps to the CLI behind the shared `_cli-probe` partial. | Pure resources — no logic, consumed by lib/template.ts | — |
-| **tests** | vitest, memfs, unit, integration, contract, e2e, knowledge-format, skill-format, token-corpus, drift, lessons-harvest, mcp-server, in-memory-transport, cli-first, station-commands, skill-invocation, factual-counts, public-docs | 測試, 單元測試, test suite, 驗證, vitest | Active | 4-layer test suite — 189 files, 4,670 tests (unit 3319 + contract 1175 + integration 45 + e2e 131). Validates every module — format and public-document contracts, the cli-first probe + station-command contracts, the drift engine, token corpus, and the MCP protocol over in-memory transport. | Quality gate — validates all layers with pyramid coverage | types, lib, services, cli, templates |
+| **tests** | vitest, memfs, unit, integration, contract, e2e, knowledge-format, skill-format, token-corpus, drift, lessons-harvest, mcp-server, in-memory-transport, cli-first, station-commands, skill-invocation, factual-counts, public-docs | 測試, 單元測試, test suite, 驗證, vitest | Active | 4-layer test suite — 189 files, 4,671 tests (unit 3320 + contract 1175 + integration 45 + e2e 131). Validates every module — format and public-document contracts, the cli-first probe + station-command contracts, the drift engine, token corpus, and the MCP protocol over in-memory transport. | Quality gate — validates all layers with pyramid coverage | types, lib, services, cli, templates |
 
 _Table format: Module | Keywords | Aliases | Status | Description | Rationale | Depends On_
 
@@ -53,7 +53,7 @@ _Optional grouping: when modules have categories and fall into ≥2 primary doma
 | **L1** | `prospec/index.md` + Core Conventions + Context-specific artifacts | At startup (acts as entry point and current task context) | ≤ 1,800 tokens per file (index.md and each core convention) |
 | **L2** | `prospec/ai-knowledge/modules/{name}/README.md` (+ each linked `{sub-module}.md`) | When Skill identifies related modules from L1 keywords | ≤ 1,000 tokens per module file — README and each linked sub-module alike; also ≤ 100 lines |
 | **Spec** | `prospec/specs/features/**/*.md` + `prospec/specs/product.md` | When Skill identifies related features (verify/archive read the specs a change touches) | ≤ 5,000 tokens per spec file — a slice under `features/{feature}/` is measured alike |
-| **Demand** | `_lessons-ledger.md`, `_playbook.md`, `_module-readme-conventions.md` | When their topic is relevant — read in slices, never whole | ≤ 10,000 tokens per file |
+| **Demand** | `_lessons-ledger.md`, `_playbook.md`, `_module-readme-conventions.md`, `_status-lifecycle.md` | When their topic is relevant — read in slices, never whole | ≤ 10,000 tokens per file |
 | **Skill** | deployed `SKILL.md` and its `references/*.md` | Injected per station by the harness | ≤ 5,000 tokens per skill, ≤ 2,500 tokens per reference — measured only where this project holds the skill template sources |
 | **L3** | Source code files | When Agent needs implementation details | No limit (read on demand) |
 

--- a/prospec/specs/_archived-history/2026-09-02-reclassify-status-lifecycle-demand.md
+++ b/prospec/specs/_archived-history/2026-09-02-reclassify-status-lifecycle-demand.md
@@ -1,0 +1,42 @@
+# reclassify-status-lifecycle-demand — Archive Summary
+
+- **Archived**: 2026-09-02
+- **Original Created**: 2026-09-02
+- **Quality Grade**: S
+- **Issue**: #249
+
+## User Story
+
+As a prospec 維護者(以及繼承出貨分類的下遊專案作者),
+I want `_status-lifecycle.md` 由 demand-knowledge 預算而非 L1 預算治理,
+So that 它 3024 tokens 的體積不再違反 prospec 自身出貨的 L1 default,消除下遊繼承的 spurious L1 over-budget WARN,且不放寬任何預設 budget。
+
+## Affected Modules
+
+| Module | Impact | Description |
+|--------|--------|-------------|
+| types | High | `CORE_CONVENTIONS`(`conventions.ts`)移除 `_status-lifecycle.md` + doc comment 說明理由 |
+| lib | None | `filterConventions`/`collectKnowledgeSize` 讀登記表,行為隨資料改變,零程式碼編輯 |
+| tests | Low | `scanner.test.ts` 新增 demand 分類 pin(比照 `_playbook.md`) |
+
+## Requirements
+
+| REQ ID | Status | Description |
+|--------|--------|-------------|
+| REQ-KNOW-035 | MODIFIED | `_status-lifecycle.md` 自 core 清單移除,歸 Load-on-Demand,以 `demand_knowledge_per_file` 評分;`additional_core_conventions` 仍可加回 core |
+
+## Completion
+
+- **Tasks**: 5/5 code tasks (100%);另 5 個 `[V]` 驗證任務完成
+- **Acceptance Criteria**: 7/7(AC-1 ~ AC-7)
+
+## Review & Verify
+
+- **Review**: 1 round, 0 critical / 0 major — review-clean(六 lens:correctness、security、spec-architecture、parallel-site-completeness、docs-claims、test-quality,fresh-context reviewer)
+- **Verify**: Grade S — machine 1/5·4/5·5/5 PASS + judgment 2/5·3/5 PASS(fresh-context)、design not-applicable;test suite 4667 passed / 4 skipped, exit 0
+- **Quality Log**: prospec-plan WARN(Architecture Verifier PASS 5/5;FR-003 bundle 措辭矛盾已修)、prospec-tasks WARN(Task Verifier 3/4 PASS,sizing advisory)、prospec-review PASS、prospec-verify S
+
+## Knowledge Update
+
+- `prospec/index.md` Conventions auto-block 與 Progressive Loading 表已同步(`_status-lifecycle.md` → Load-on-Demand Conventions);無模組 README 描述需變更(knowledge-health PASS)
+- 成效:`prospec check` knowledge-size 由 49→48 warn,`_status-lifecycle.md` 的 L1 over-budget finding 消除;無任何預設或覆寫 budget 值變動

--- a/prospec/specs/features/ai-knowledge.md
+++ b/prospec/specs/features/ai-knowledge.md
@@ -1,7 +1,7 @@
 ---
 feature: ai-knowledge
 status: active
-last_updated: 2026-09-01
+last_updated: 2026-09-02
 story_count: 15
 req_count: 74
 ---
@@ -122,6 +122,7 @@ The test suite proves the Module README format contract at every boundary using 
 
 | Date | Change | Impact | Stories/REQs |
 |------|--------|--------|-------------|
+| 2026-09-02 | reclassify-status-lifecycle-demand | MODIFIED REQ-KNOW-035 | REQ-KNOW-035 |
 | 2026-09-01 | standardize-module-readme-format | ADDED REQ-TYPES-093; ADDED REQ-LIB-073; ADDED REQ-SERVICES-105; ADDED REQ-CLI-050; ADDED REQ-TEMPLATES-226; ADDED REQ-TESTS-110; MODIFIED REQ-KNOW-004; MODIFIED REQ-KNOW-015; MODIFIED REQ-TEMPLATES-122 | REQ-TYPES-093, REQ-LIB-073, REQ-SERVICES-105, REQ-CLI-050, REQ-TEMPLATES-226, REQ-TESTS-110, REQ-KNOW-004, REQ-KNOW-015, REQ-TEMPLATES-122 |
 | 2026-08-31 | retire-legacy-index-migration | MODIFIED REQ-KNOW-034; MODIFIED REQ-KNOW-035 | REQ-KNOW-034, REQ-KNOW-035 |
 | 2026-08-27 | align-knowledge-check-attribution | ADDED REQ-LIB-062; ADDED REQ-SERVICES-097; ADDED REQ-CLI-042; MODIFIED REQ-TEMPLATES-162 | REQ-LIB-062, REQ-SERVICES-097, REQ-CLI-042, REQ-TEMPLATES-162 |

--- a/prospec/specs/features/ai-knowledge/us-351.md
+++ b/prospec/specs/features/ai-knowledge/us-351.md
@@ -115,8 +115,8 @@ The root-level `{base_dir}/index.md` is the single L1 entry point.
 
 #### REQ-KNOW-035: Conventions Loading Filtering
 Convention files are classified from the core registry plus project configuration; every scanned non-core convention is load-on-demand.
-- WHEN index file is generated, THEN core files (`_conventions.md`, `_diagram-conventions.md`, `_glossary.md`, `_status-lifecycle.md`, plus anything `.prospec.yaml` `knowledge.additional_core_conventions` promotes) are listed in the Core Conventions (L1) section (actively read at task start, NOT auto-loaded).
-- WHEN dynamically scanning `ai-knowledge/` for `_*.md` files, THEN non-core files (incl. `_playbook.md` and `_lessons-ledger.md`) are listed in the **Load-on-Demand Conventions** section — the heading carries no layer tag, because these files are graded against `demand_knowledge_per_file`, not the L2 per-module budget.
+- WHEN index file is generated, THEN core files (`_conventions.md`, `_diagram-conventions.md`, `_glossary.md`, plus anything `.prospec.yaml` `knowledge.additional_core_conventions` promotes) are listed in the Core Conventions (L1) section (actively read at task start, NOT auto-loaded).
+- WHEN dynamically scanning `ai-knowledge/` for `_*.md` files, THEN non-core files (incl. `_status-lifecycle.md`, `_playbook.md` and `_lessons-ledger.md`) are listed in the **Load-on-Demand Conventions** section — the heading carries no layer tag, because these files are graded against `demand_knowledge_per_file`, not the L2 per-module budget.
 - WHEN a core file is missing, THEN it is gracefully skipped without breaking the generation process.
 
 ---

--- a/prospec/specs/product.md
+++ b/prospec/specs/product.md
@@ -1,7 +1,7 @@
 ---
 product: prospec
 version: 1.0.0
-last_updated: 2026-09-01
+last_updated: 2026-09-02
 ---
 
 # prospec — Progressive Spec-Driven Development for AI agents

--- a/src/types/conventions.ts
+++ b/src/types/conventions.ts
@@ -122,13 +122,16 @@ export const CANONICAL_INIT_DOCS = INIT_DOC_REGISTRY.filter(doc => doc.canonical
 
 /**
  * Core convention files (L1) that agents must read at the start of every task.
- * Any convention not in this list is treated as a load-on-demand (L2) convention.
+ * Any convention not in this list is treated as a load-on-demand convention,
+ * graded against `demand_knowledge_per_file` (never the L1 per-file budget).
  * `_playbook.md` is deliberately absent: feedback-promotion governance keeps it
  * load-on-demand (progressive disclosure, TTL-governed), never core.
+ * `_status-lifecycle.md` is likewise absent: its executable copy is the
+ * `prospec status` CLI (`lib/status-router.ts`) — agents read the command output,
+ * not the markdown — so it is load-on-demand reference, not always-on L1.
  */
 export const CORE_CONVENTIONS = [
   '_conventions.md',
   '_diagram-conventions.md',
   '_glossary.md',
-  '_status-lifecycle.md',
 ];

--- a/tests/unit/lib/scanner.test.ts
+++ b/tests/unit/lib/scanner.test.ts
@@ -284,6 +284,13 @@ describe('filterConventions (core/demand split, REQ-KNOW-035)', () => {
     expect(demand).toEqual(['_playbook.md']);
   });
 
+  it('keeps _status-lifecycle.md load-on-demand — its executable copy is the `prospec status` CLI, not the markdown', () => {
+    expect(CORE_CONVENTIONS).not.toContain('_status-lifecycle.md');
+    const { core, demand } = filterConventions(['_conventions.md', '_status-lifecycle.md']);
+    expect(core).toEqual(['_conventions.md']);
+    expect(demand).toEqual(['_status-lifecycle.md']);
+  });
+
   it('classifies _index.md like any other non-core convention', () => {
     const { core, demand } = filterConventions(['_index.md', '_conventions.md', '_custom.md']);
     expect(core).toEqual(['_conventions.md']);


### PR DESCRIPTION
## 背景

`prospec/ai-knowledge/_status-lifecycle.md` 被列在 `CORE_CONVENTIONS`,由 `knowledge-size` 當作 **L1 core convention** 評分。它實測 **3024 tokens**,超過 prospec 出貨的 L1 default **1800**(68%),連本 repo 已放寬的覆寫 **2500** 也超 21%。由於它是出貨的 canonical 模板(`src/templates/init/status-lifecycle.md.hbs`),**每個 `prospec init` 的下遊專案都原封繼承這 3024 tokens 的 L1 檔案**,一開機 `prospec check` 就掛著一條它作者從沒寫過、且違反 prospec 自身出貨 L1 default 的 WARN——產品內部的自我矛盾。

根因是**分類**,不是預算校準:`_status-lifecycle.md` 的 executable copy 是 `prospec status` CLI(`src/lib/status-router.ts`),agent 讀的是指令輸出而非 markdown——與已是 demand-knowledge 的 `_playbook.md`、`_module-readme-conventions.md` 同型。其餘三個 core convention(`_conventions.md` 1266、`_diagram-conventions.md` 811、`_glossary.md` 859)皆遠在 1800 內,證明 default 並非系統性偏緊,離群值只有此一檔。

## 改了什麼

**把 `_status-lifecycle.md` 從 `CORE_CONVENTIONS` 移除,改由 demand-knowledge 預算治理。** 這是最小資料面改動:僅移除登記表一項(`src/types/conventions.ts`),讓既有的單一來源機制自然反應——`filterConventions`(`lib/scanner.ts`)改把它歸 demand、`collectKnowledgeSize` 改以 `demand_knowledge_per_file`(default 10000)評分、`index.md` 自動塊改列於 Load-on-Demand。3024 tokens 有 3 倍以上餘裕。**無新增 writer/parser/formatter、無 `.hbs` 改動、不動任何預設或覆寫 budget 值**——紀律不放寬,方向與「抬 default 遷就胖檔案」相反。比照 `_module-readme-conventions.md`(同為 canonical 出貨、非 core、demand)的既有先例。

**規格與守衛。** MODIFIED `REQ-KNOW-035`(`ai-knowledge/us-351.md`):core 清單移除 `_status-lifecycle.md`、demand 清單納入;`scanner.test.ts` 新增分類 pin(比照 `_playbook.md` 案例,實作前紅、後綠)。`index.md` Progressive Loading 表 Demand 列同步。

## 驗證

- `pnpm test`:**4667 passed / 4 skipped(4671,189 files)**,exit 0;coverage Statements 96.64%。
- `prospec check`:20 checks,**0 fail / 1 warn**。該 warn 為 `knowledge-size`,是 pre-existing 超標的 skill/spec/L2 檔(與本變更無關);本變更使其 finding 由 **49 → 48**——`_status-lifecycle.md` 的 L1 over-budget finding 消除。
- CI parity 全綠:`lint`、`typecheck`、`counts:check`、`agents:check`、`knowledge:check`、`prospec check --strict`。
- `/prospec-review`:review-clean(0 critical / 0 major,六 lens、fresh-context reviewer)。
- `/prospec-verify`:**Grade S** — machine 1/5·4/5·5/5 PASS + judgment 2/5·3/5 PASS(fresh-context)、design not-applicable。
- `/prospec-archive`:已執行,`REQ-KNOW-035` 已畢業進 `us-351.md`,`_archived-history` 已記錄。

## 誠實揭露

- `knowledge-size` 仍有 **48 筆** WARN,全為 pre-existing 超標的 skill/spec/L2 檔案,不在本 PR 範圍;本變更僅移除其中 `_status-lifecycle.md` 一筆。
- 兩個 planning verifier advisory 皆於過程中處理:plan 站 Architecture Verifier(PASS 5/5)指出 proposal FR-003 的 `pnpm bundle` 措辭與 plan 牴觸,已修正 FR-003;tasks 站 Task Verifier(PASS 3/4)的 sizing WARN 屬相稱於 ~29 行微變更的 advisory,非結構缺陷。

Closes #249
